### PR TITLE
GCP Provider Pin & MIG Updates

### DIFF
--- a/instance.tf
+++ b/instance.tf
@@ -1,5 +1,5 @@
 resource "google_compute_instance_template" "sensor_template" {
-  name         = var.instance_template_resource_name
+  name_prefix  = var.instance_template_resource_name_prefix
   machine_type = var.instance_size
   tags         = ["allow-ssh", "corelight", "sensor", "allow-health-check"]
 
@@ -35,7 +35,7 @@ resource "google_compute_instance_template" "sensor_template" {
   }
 
   lifecycle {
-    create_before_destroy = false
+    create_before_destroy = true
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -119,10 +119,10 @@ variable "community_string" {
   description = "the community string (api string) often times referenced by Fleet"
 }
 
-variable "instance_template_resource_name" {
+variable "instance_template_resource_name_prefix" {
   type        = string
-  default     = "corelight-mig-template"
-  description = "the name of the instance template resource"
+  default     = "corelight-mig-template-"
+  description = "the name prefix of the instance template resource"
 }
 
 variable "instance_template_group_manager_resource_name" {

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">=1.3.2"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5"
+    }
+  }
+}


### PR DESCRIPTION
# Description

Fixing two issues: 
1. Issue where upgrading the instance template was unsuccessful due to name collision. Now we set a prefix.
2. Pinned the terraform module to v5 as v6 broke the MIG API contract

## Type of change

Please delete options that are not relevant.

- [x] Bug Fix
- [ ] New Feature
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested locally successfully