### PR TITLE
Bump provider version

### DIFF
--- a/load_balancer.tf
+++ b/load_balancer.tf
@@ -38,8 +38,10 @@ resource "google_compute_region_backend_service" "traffic_ilb_backend_service" {
   load_balancing_scheme = "INTERNAL"
   session_affinity      = "NONE"
 
+
   backend {
     group = google_compute_region_instance_group_manager.sensor_mig.instance_group
+    balancing_mode = "CONNECTION"
   }
 }
 

--- a/load_balancer.tf
+++ b/load_balancer.tf
@@ -40,7 +40,7 @@ resource "google_compute_region_backend_service" "traffic_ilb_backend_service" {
 
 
   backend {
-    group = google_compute_region_instance_group_manager.sensor_mig.instance_group
+    group          = google_compute_region_instance_group_manager.sensor_mig.instance_group
     balancing_mode = "CONNECTION"
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 5"
+      version = ">=6.38.0"
     }
   }
 }


### PR DESCRIPTION
# Description

Bumps GCP provider version to 6.38.0

## Type of change

Please delete options that are not relevant.

- [ ] Bug Fix
- [ ] New Feature
- [ ] This change requires a documentation update

# How Has This Been Tested?

Deployed successfully
