### PR TITLE
make license_key optional if fleet_url is provided

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -113,9 +113,15 @@ variable "health_check_http_port" {
 }
 
 variable "license_key" {
-  description = "Your Corelight sensor license key"
-  type        = string
+  description = "Your Corelight sensor license key. Optional if fleet_url is configured."
   sensitive   = true
+  type        = string
+  default     = ""
+
+  validation {
+    condition     = var.license_key != "" || var.fleet_url != ""
+    error_message = "Either license_key must be provided or fleet_url must be configured."
+  }
 }
 
 variable "community_string" {


### PR DESCRIPTION
This PR makes license_key optional if fleet_url is provided